### PR TITLE
Reflect ResourceNoders, fix reflection on []Resource

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -25,6 +25,9 @@ func (r *Resource) Message(tag string) *Message {
 	return NewMessage(RsRes).AddArg(tag).AddArg("/" + strings.Join(r.path, "/")).AddArg(vtype).AddArg(val)
 }
 
+// TODO(CaptainHayashi): Do we need all this machinery?
+// []Resources are practically only emitted by converting ResourceNodes!
+
 // Resourcifier is the interface for things that can be converted to resource
 // lists.
 type Resourcifier interface {
@@ -60,13 +63,8 @@ func toResourceReflect(path []string, val reflect.Value, typ reflect.Type) []Res
 		return structToResource(path, val, typ)
 	case reflect.Array, reflect.Slice:
 		return sliceToResource(path, val, typ)
-	case reflect.Int:
-		// TODO(CaptainHayashi): catch more integers here?
-		return []Resource{{path: path, value: BifrostTypeInt(val.Int())}}
 	default:
-		// TODO(CaptainHayashi): enums?
-		item := val.Interface()
-		return []Resource{{path: path, value: BifrostTypeString(fmt.Sprint(item))}}
+		return []Resource{{path: path, value: ToBifrostType(val.Interface())}}
 	}
 }
 

--- a/resource.go
+++ b/resource.go
@@ -82,7 +82,7 @@ func structToResource(path []string, val reflect.Value, typ reflect.Type) []Reso
 
 		// We can't announce fields that aren't exported.
 		// If this one isn't, knock one off the available fields and ignore it.
-		if fieldt.PkgPath != "" {
+		if fieldt.PkgPath != "" || fieldt.Anonymous {
 			af--
 			continue
 		}

--- a/resourcetree.go
+++ b/resourcetree.go
@@ -2,8 +2,6 @@ package bifrost
 
 import (
 	"fmt"
-	"reflect"
-	"strconv"
 	"strings"
 )
 
@@ -26,116 +24,6 @@ func splitPath(path string) []string {
 		splitPath = append(splitPath, currentSegment) // Whatever we have left
 	}
 	return splitPath
-}
-
-type Resource struct {
-	path  []string
-	value BifrostType
-}
-
-func (r *Resource) String() string {
-	return fmt.Sprintf("/%s %s", strings.Join(r.path, "/"), r.value.String())
-}
-
-// Message flattens a Resource into a Bifrost RES, given the tag of the read
-// generating it.
-//
-// TODO(CaptainHayashi): does this belong elsewhere?
-func (r *Resource) Message(tag string) *Message {
-	vtype, val := r.value.ResourceBody()
-	return NewMessage(RsRes).AddArg(tag).AddArg("/" + strings.Join(r.path, "/")).AddArg(vtype).AddArg(val)
-}
-
-// Resourcifier is the interface for things that can be converted to resource
-// lists.
-type Resourcifier interface {
-	// Resourcify converts a Resourcifier into a list of resources.
-	Resourcify(path []string) []Resource
-}
-
-// ToResource converts an item and its location in the tree to a list of resources.
-// If the item is a Resourcifier, Resourcify() is called on it.
-// Struct fields may be annotated with a `res` tag giving the name the
-// corresponding child should take in the resource.
-func ToResource(path []string, item interface{}) []Resource {
-	// First, see if item can do the work for us.
-	switch item := item.(type) {
-	case Resourcifier:
-		return item.Resourcify(path)
-	default:
-		return toResourceReflect(path, reflect.ValueOf(item), reflect.TypeOf(item))
-	}
-}
-
-func toResourceReflect(path []string, val reflect.Value, typ reflect.Type) []Resource {
-	switch val.Kind() {
-	case reflect.Ptr:
-		// Don't call toResourceReflect here; otherwise, we'll forget
-		// to check to see if it's a Resourcifier.
-		return ToResource(path, reflect.Indirect(val).Interface())
-	case reflect.Struct:
-		return structToResource(path, val, typ)
-	case reflect.Array, reflect.Slice:
-		return sliceToResource(path, val, typ)
-	case reflect.Int:
-		// TODO(CaptainHayashi): catch more integers here?
-		return []Resource{{path: path, value: BifrostTypeInt(val.Int())}}
-	default:
-		// TODO(CaptainHayashi): enums?
-		item := val.Interface()
-		return []Resource{{path: path, value: BifrostTypeString(fmt.Sprint(item))}}
-	}
-}
-
-func structToResource(path []string, val reflect.Value, typ reflect.Type) []Resource {
-	nf := val.NumField()
-	af := nf
-
-	// First, reserve space for the incoming directory.
-	// We'll fix the inner value later.
-	res := []Resource{{path: path, value: nil}}
-
-	// Now, recursively work out the fields.
-	for i := 0; i < nf; i++ {
-		fieldt := typ.Field(i)
-
-		// We can't announce fields that aren't exported.
-		// If this one isn't, knock one off the available fields and ignore it.
-		if fieldt.PkgPath != "" {
-			af--
-			continue
-		}
-
-		// Work out the resource name from the field name/tag.
-		tag := fieldt.Tag.Get("res")
-		if tag == "" {
-			tag = fieldt.Name
-		}
-
-		// Now, recursively emit and collate each resource.
-		fieldv := val.Field(i)
-		res = append(res, ToResource(append(path, tag), fieldv.Interface())...)
-	}
-
-	// Now fill in the final available fields count
-	res[0].value = BifrostTypeDirectory{numChildren: af}
-
-	return res
-}
-
-func sliceToResource(path []string, val reflect.Value, typ reflect.Type) []Resource {
-	len := val.Len()
-
-	// As before, but now with a list and indexes.
-	// TODO(CaptainHayashi): modelling a list as a directory
-	res := []Resource{{path, BifrostTypeDirectory{numChildren: len}}}
-
-	for i := 0; i < len; i++ {
-		fieldv := val.Index(i)
-		res = append(res, ToResource(append(path, strconv.Itoa(i)), fieldv.Interface())...)
-	}
-
-	return res
 }
 
 type Response struct {

--- a/resourcetree.go
+++ b/resourcetree.go
@@ -144,6 +144,10 @@ func (n DirectoryResourceNode) NDelete(prefix, relpath []string) error {
 	return nil
 }
 
+func (n DirectoryResourceNode) Resourcify(path []string) []Resource {
+	return ToResource(path, map[string]ResourceNoder(n))
+}
+
 type EntryResourceNode struct {
 	ResourceNode
 	Value BifrostType
@@ -175,4 +179,8 @@ func (n EntryResourceNode) NWrite(prefix, relpath []string, value BifrostType) e
 
 func (n EntryResourceNode) NDelete(prefix, relpath []string) error {
 	return nil
+}
+
+func (n EntryResourceNode) Resourcify(path []string) []Resource {
+	return ToResource(path, n.Value)
 }

--- a/resourcetree.go
+++ b/resourcetree.go
@@ -230,7 +230,6 @@ func toNodeReflect(val reflect.Value, typ reflect.Type) ResourceNoder {
 
 func structToNode(val reflect.Value, typ reflect.Type) ResourceNoder {
 	nf := val.NumField()
-	af := nf
 
 	children := map[string]ResourceNoder{}
 
@@ -240,8 +239,7 @@ func structToNode(val reflect.Value, typ reflect.Type) ResourceNoder {
 
 		// We can't announce fields that aren't exported.
 		// If this one isn't, knock one off the available fields and ignore it.
-		if fieldt.PkgPath != "" {
-			af--
+		if fieldt.PkgPath != "" || fieldt.Anonymous {
 			continue
 		}
 

--- a/resourcetree.go
+++ b/resourcetree.go
@@ -30,6 +30,7 @@ func splitPath(path string) []string {
 
 type Response struct {
 	Status Status
+	Path   []string
 	Node   ResourceNoder
 }
 
@@ -57,6 +58,7 @@ func Read(r ResourceNoder, path string) Response {
 	}
 	return Response{
 		status,
+		splitPath,
 		node,
 	}
 }
@@ -75,6 +77,7 @@ func Write(r ResourceNoder, path, value string) Response {
 	}
 	return Response{
 		status,
+		splitPath,
 		nil,
 	}
 }

--- a/resourcetree_test.go
+++ b/resourcetree_test.go
@@ -106,3 +106,51 @@ func TestAdd(t *testing.T) {
 		}
 	}
 }
+
+// TestResourcify ensures that the stock resource tree nodes are giving us
+// decent []Resource lists.
+func TestResourcify(t *testing.T) {
+	cases := []struct {
+		have ResourceNoder
+		want []Resource
+	}{
+		{
+			NewEntryResourceNode(BifrostTypeString("fus ro dah")),
+			[]Resource{
+				Resource{[]string{}, BifrostTypeString("fus ro dah")},
+			},
+		},
+		{
+			NewEntryResourceNode(BifrostTypeInt(8675309)),
+			[]Resource{
+				Resource{[]string{}, BifrostTypeInt(8675309)},
+			},
+		},
+		{
+			NewDirectoryResourceNode(
+				map[string]ResourceNoder{
+					"we're":  NewEntryResourceNode(BifrostTypeString("only")),
+					"making": NewEntryResourceNode(BifrostTypeString("plans")),
+					"for":    NewEntryResourceNode(BifrostTypeString("Nigel")),
+				},
+			),
+			[]Resource{
+				// 3 entries
+				Resource{[]string{}, BifrostTypeDirectory{3}},
+				Resource{[]string{"we're"}, BifrostTypeString("only")},
+				Resource{[]string{"making"}, BifrostTypeString("plans")},
+				Resource{[]string{"for"}, BifrostTypeString("Nigel")},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		got := ToResource([]string{}, c.have)
+		// TODO(CaptainHayashi): Technically DeepEqual is too strict
+		// here--we want to be able to ignore ordering in the
+		// []Resource.
+		if !reflect.DeepEqual(got, c.want) {
+			t.Fatalf("bad resourcify: have %q, got %q, want %q", c.have, got, c.want)
+		}
+	}
+}

--- a/response.go
+++ b/response.go
@@ -1,0 +1,118 @@
+package bifrost
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type Resource struct {
+	path  []string
+	value BifrostType
+}
+
+func (r *Resource) String() string {
+	return fmt.Sprintf("/%s %s", strings.Join(r.path, "/"), r.value.String())
+}
+
+// Message flattens a Resource into a Bifrost RES, given the tag of the read
+// generating it.
+//
+// TODO(CaptainHayashi): does this belong elsewhere?
+func (r *Resource) Message(tag string) *Message {
+	vtype, val := r.value.ResourceBody()
+	return NewMessage(RsRes).AddArg(tag).AddArg("/" + strings.Join(r.path, "/")).AddArg(vtype).AddArg(val)
+}
+
+// Resourcifier is the interface for things that can be converted to resource
+// lists.
+type Resourcifier interface {
+	// Resourcify converts a Resourcifier into a list of resources.
+	Resourcify(path []string) []Resource
+}
+
+// ToResource converts an item and its location in the tree to a list of resources.
+// If the item is a Resourcifier, Resourcify() is called on it.
+// Struct fields may be annotated with a `res` tag giving the name the
+// corresponding child should take in the resource.
+func ToResource(path []string, item interface{}) []Resource {
+	// First, see if item can do the work for us.
+	switch item := item.(type) {
+	case Resourcifier:
+		return item.Resourcify(path)
+	default:
+		return toResourceReflect(path, reflect.ValueOf(item), reflect.TypeOf(item))
+	}
+}
+
+func toResourceReflect(path []string, val reflect.Value, typ reflect.Type) []Resource {
+	switch val.Kind() {
+	case reflect.Ptr:
+		// Don't call toResourceReflect here; otherwise, we'll forget
+		// to check to see if it's a Resourcifier.
+		return ToResource(path, reflect.Indirect(val).Interface())
+	case reflect.Struct:
+		return structToResource(path, val, typ)
+	case reflect.Array, reflect.Slice:
+		return sliceToResource(path, val, typ)
+	case reflect.Int:
+		// TODO(CaptainHayashi): catch more integers here?
+		return []Resource{{path: path, value: BifrostTypeInt(val.Int())}}
+	default:
+		// TODO(CaptainHayashi): enums?
+		item := val.Interface()
+		return []Resource{{path: path, value: BifrostTypeString(fmt.Sprint(item))}}
+	}
+}
+
+func structToResource(path []string, val reflect.Value, typ reflect.Type) []Resource {
+	nf := val.NumField()
+	af := nf
+
+	// First, reserve space for the incoming directory.
+	// We'll fix the inner value later.
+	res := []Resource{{path: path, value: nil}}
+
+	// Now, recursively work out the fields.
+	for i := 0; i < nf; i++ {
+		fieldt := typ.Field(i)
+
+		// We can't announce fields that aren't exported.
+		// If this one isn't, knock one off the available fields and ignore it.
+		if fieldt.PkgPath != "" {
+			af--
+			continue
+		}
+
+		// Work out the resource name from the field name/tag.
+		tag := fieldt.Tag.Get("res")
+		if tag == "" {
+			tag = fieldt.Name
+		}
+
+		// Now, recursively emit and collate each resource.
+		fieldv := val.Field(i)
+		res = append(res, ToResource(append(path, tag), fieldv.Interface())...)
+	}
+
+	// Now fill in the final available fields count
+	res[0].value = BifrostTypeDirectory{numChildren: af}
+
+	return res
+}
+
+func sliceToResource(path []string, val reflect.Value, typ reflect.Type) []Resource {
+	len := val.Len()
+
+	// As before, but now with a list and indexes.
+	// TODO(CaptainHayashi): modelling a list as a directory
+	res := []Resource{{path, BifrostTypeDirectory{numChildren: len}}}
+
+	for i := 0; i < len; i++ {
+		fieldv := val.Index(i)
+		res = append(res, ToResource(append(path, strconv.Itoa(i)), fieldv.Interface())...)
+	}
+
+	return res
+}

--- a/type.go
+++ b/type.go
@@ -1,6 +1,7 @@
 package bifrost
 
 import (
+	"fmt"
 	"strconv"
 )
 
@@ -51,4 +52,18 @@ func (t BifrostTypeDirectory) String() string {
 }
 func (t BifrostTypeDirectory) ResourceBody() (string, string) {
 	return "directory", strconv.Itoa(t.numChildren)
+}
+
+// ToBifrostType converts a value to a BifrostType.
+// It will return a BifrostTypeInt if the value is an integer, and
+// BifrostTypeString otherwise (converting the value to a string).
+func ToBifrostType(v interface{}) BifrostType {
+	switch v := v.(type) {
+	case int:
+		return BifrostTypeInt(v)
+	case string:
+		return BifrostTypeString(v)
+	default:
+		return BifrostTypeString(fmt.Sprint(v))
+	}
 }


### PR DESCRIPTION
- Allow `ToResource` to go through pointers.
- Allow `ToResource` to be overridden via a `Resourcifier` interface, which specifies custom behaviour.
- Add a test for `ToResource`.
- Add a similar reflection for converting anything to a `ResourceNoder` (structs, maps and arrays/slices go to `DirectoryResourceNode`; anything else to an `EntryResourceNode`);
- Make both reflections ignore embedded structs.

I'm not sure if `ToResource` needs to exist, now.  There's a lot of overlap in both reflections, and the only thing you'd ever want to convert to a `[]Resource` is a `ResourceNoder`, anyway.

Comments appreciated.
