### PR TITLE
Remove MessageWords in favour of strings.

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -114,10 +114,7 @@ func (c *Connector) handleResponse(line []string) error {
 		return err
 	}
 
-	if !msg.Word().IsUnknown() {
-		c.resCh <- *msg
-	}
-
+	c.resCh <- *msg
 	return nil
 }
 

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -3,42 +3,6 @@ package message
 import "testing"
 import "reflect"
 
-func TestMessageWord(t *testing.T) {
-	cases := []struct {
-		str     string
-		word    MessageWord
-		unknown bool
-	}{
-		// Ok, a request
-		{"read", RqRead, false},
-		// Ok, a response
-		{"OHAI", RsOhai, false},
-		// Unknown, but a request
-		{"uwot", RqUnknown, true},
-		// Unknown, but a response
-		{"MATE", RsUnknown, true},
-		// Unknown, and unclear what type of message
-		{"MaTe", BadWord, true},
-	}
-
-	for _, c := range cases {
-		gotword := LookupWord(c.str)
-		if gotword != c.word {
-			t.Errorf("LookupWord(%q) == %q, want %q", c.str, gotword, c.word)
-		}
-		if c.word.IsUnknown() != c.unknown {
-			t.Errorf("%q.IsUnknown() == %q, want %q", c.word, !c.unknown, c.unknown)
-		}
-		// Only do the other direction if it's a valid response
-		if !c.unknown {
-			gotstr := c.word.String()
-			if gotstr != c.str {
-				t.Errorf("%q.String() == %q, want %q", c.word, gotstr, c.str)
-			}
-		}
-	}
-}
-
 func TestMessage(t *testing.T) {
 	cases := []struct {
 		words []string
@@ -77,16 +41,15 @@ func TestMessage(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		gotword := LookupWord(c.words[0])
-		if gotword != c.msg.Word() {
-			t.Errorf("LookupWord(%q) == %q, but Word() == %q", c.words[0], gotword, c.msg.Word())
+		if c.words[0] != c.msg.Word() {
+			t.Errorf("Word() == %q, expected %q", c.msg.Word(), c.words[0])
 		}
 	}
 
 	// And now, test args.
 	// TODO(CaptainHayashi): refactor the above to integrate this test
 	args := []string{"bibbity", "bobbity", "boo"}
-	msg := New(RsUnknown)
+	msg := New("flax")
 	for _, arg := range args {
 		msg.AddArg(arg)
 	}


### PR DESCRIPTION
This simplifies the message implementation dramatically, allows
non-standard messages to be routed by bifrost-go, and will allow
further simplifications down the road.

Most of the Rs\* and Rq\* constants still exist, but now point
directly to their former `.String()` equivalents.

If your code relied on BadWord, RsUnknown, RqUnknown, etc., or
MessageWord being a distinct thing, it is now broken.  If it only
used the other Rq\* and Rs\* constants, it may be fine.
